### PR TITLE
別ページにデータを送信 ( PRしないで )

### DIFF
--- a/-remote
+++ b/-remote
@@ -1,0 +1,18 @@
+  feat_add_word[m
+  feat_add_words[m
+  feat_result_view[m
+  feat_timer_limited[m
+  feat_typing_battle[m
+  feat_typing_login[m
+  fix_word_clear[m
+* [32mmain[m
+  refactor_typing_battle[m
+  [31mremotes/origin/HEAD[m -> origin/main
+  [31mremotes/origin/feat_add_word[m
+  [31mremotes/origin/feat_result_view[m
+  [31mremotes/origin/feat_timer_limited[m
+  [31mremotes/origin/feat_typing_battle[m
+  [31mremotes/origin/feat_typing_login[m
+  [31mremotes/origin/fix_word_clear[m
+  [31mremotes/origin/main[m
+  [31mremotes/origin/refactor_typing_battle[m

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "clsx": "^1.1.1",
     "firebase": "^9.6.10",
     "firebase-admin": "^10.0.2",
+    "jotai": "^1.6.1",
     "next": "12.1.0",
     "react": "17.0.2",
     "react-dom": "17.0.2"

--- a/src/libs/Atom.ts
+++ b/src/libs/Atom.ts
@@ -19,3 +19,6 @@ export const enemyWordsAtom = atom<word[]>([])
 //   { value: 'anpan', enemy: false },
 //   { value: 'start', enemy: false },
 // ])
+
+export const wordsArrayAtom = atom<string[]>([])
+export const enemyWordsArrayAtom = atom<string[]>([])

--- a/src/libs/Atom.ts
+++ b/src/libs/Atom.ts
@@ -5,19 +5,20 @@ interface word {
   enemy: boolean
 }
 
-export const indextAtom = atom<number>(0)
-export const enemyIndextAtom = atom<number>(0)
 export const textAtom = atom<string>('')
 export const enemyTextAtom = atom<string>('')
+export const indextAtom = atom<number>(0)
+export const enemyIndextAtom = atom<number>(0)
+
+// [{}]のデータをindexで定義し、使うことはできるが、別ページでは使えない
+// 配列なら使える
 export const wordsAtom = atom<word[]>([])
 export const enemyWordsAtom = atom<word[]>([])
 // export const wordsAtom = atom<word[]>([
 //   { value: 'anpan', enemy: false },
-//   { value: 'start', enemy: false },
 // ])
 // export const enemyWordsAtom = atom<word[]>([
 //   { value: 'anpan', enemy: false },
-//   { value: 'start', enemy: false },
 // ])
 
 export const wordsArrayAtom = atom<string[]>([])

--- a/src/libs/Atom.ts
+++ b/src/libs/Atom.ts
@@ -9,17 +9,5 @@ export const textAtom = atom<string>('')
 export const enemyTextAtom = atom<string>('')
 export const indextAtom = atom<number>(0)
 export const enemyIndextAtom = atom<number>(0)
-
-// [{}]のデータをindexで定義し、使うことはできるが、別ページでは使えない
-// 配列なら使える
 export const wordsAtom = atom<word[]>([])
 export const enemyWordsAtom = atom<word[]>([])
-// export const wordsAtom = atom<word[]>([
-//   { value: 'anpan', enemy: false },
-// ])
-// export const enemyWordsAtom = atom<word[]>([
-//   { value: 'anpan', enemy: false },
-// ])
-
-export const wordsArrayAtom = atom<string[]>([])
-export const enemyWordsArrayAtom = atom<string[]>([])

--- a/src/libs/Atom.ts
+++ b/src/libs/Atom.ts
@@ -1,0 +1,21 @@
+import { atom } from 'jotai'
+
+interface word {
+  value: string
+  enemy: boolean
+}
+
+export const indextAtom = atom<number>(0)
+export const enemyIndextAtom = atom<number>(0)
+export const textAtom = atom<string>('')
+export const enemyTextAtom = atom<string>('')
+export const wordsAtom = atom<word[]>([])
+export const enemyWordsAtom = atom<word[]>([])
+// export const wordsAtom = atom<word[]>([
+//   { value: 'anpan', enemy: false },
+//   { value: 'start', enemy: false },
+// ])
+// export const enemyWordsAtom = atom<word[]>([
+//   { value: 'anpan', enemy: false },
+//   { value: 'start', enemy: false },
+// ])

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,9 @@
 import '../styles/globals.css'
 import type { AppProps } from 'next/app'
-
+// const Provider: React.FC<{
+//   initialValues?: Iterable<readonly [AnyAtom, unknown]>
+//   scope?: Scope
+// }>
 function MyApp({ Component, pageProps }: AppProps) {
   return <Component {...pageProps} />
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,9 +1,5 @@
 import '../styles/globals.css'
 import type { AppProps } from 'next/app'
-// const Provider: React.FC<{
-//   initialValues?: Iterable<readonly [AnyAtom, unknown]>
-//   scope?: Scope
-// }>
 function MyApp({ Component, pageProps }: AppProps) {
   return <Component {...pageProps} />
 }

--- a/src/pages/chat.tsx
+++ b/src/pages/chat.tsx
@@ -10,15 +10,17 @@ import {
   orderBy,
 } from 'firebase/firestore'
 import { NextPage } from 'next'
+import Link from 'next/link'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useWordSendingBot } from 'hooks/useWordSendingBot'
 import { db } from 'libs/firebase'
-import Link from 'next/link'
 
 const ChatPage: NextPage = () => {
   const [data, setData] = useState<DocumentData[]>()
-  const [formParams, setFormParams] =
-    useState<{ value: string; userName: string }>()
+  const [formParams, setFormParams] = useState<{
+    value: string
+    userName: string
+  }>()
   const reference = useMemo(() => collection(db, 'rooms'), [])
 
   useEffect(() => {
@@ -69,7 +71,9 @@ const ChatPage: NextPage = () => {
   return (
     <>
       <header>
-        <Link href='/'>typing</Link>
+        <Link href='/'>
+          <a>typing</a>
+        </Link>
       </header>
       <div className='mx-8 mb-60'>
         {data &&

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,15 +1,14 @@
 import { useAtom } from 'jotai'
 import Link from 'next/link'
+import { useRouter } from 'next/router'
 import React, { useCallback, useEffect, useMemo, useState, VFC } from 'react'
 import { wordList } from 'dev/wordList'
 import { useTimer } from 'hooks/useTimer'
 import {
   enemyIndextAtom,
-  enemyTextAtom,
   enemyWordsArrayAtom,
   enemyWordsAtom,
   indextAtom,
-  textAtom,
   wordsArrayAtom,
   wordsAtom,
 } from 'libs/Atom'
@@ -23,14 +22,12 @@ interface wordData {
 }
 
 const Home: VFC = () => {
-  // const [text, setText] = useState<string>('')
-  // const [enemyText, setEnemyText] = useState<string>('')
+  const [text, setText] = useState<string>('')
+  const [enemyText, setEnemyText] = useState<string>('')
   // const [index, setIndex] = useState<number>(0)
   // const [enemyIndex, setEnemyIndex] = useState<number>(0)
   // const [words, setWords] = useState<wordData[]>()
   // const [enemyWords, setEnemyWords] = useState<wordData[]>()
-  const [text, setText] = useAtom(textAtom)
-  const [enemyText, setEnemyText] = useAtom(enemyTextAtom)
   const [index, setIndex] = useAtom(indextAtom)
   const [enemyIndex, setEnemyIndex] = useAtom(enemyIndextAtom)
   const [words, setWords] = useAtom(wordsAtom)
@@ -49,6 +46,8 @@ const Home: VFC = () => {
 
   const displayWords = useMemo(() => shuffleArray(wordList), [])
   const displayEnemyWords = useMemo(() => shuffleArray(wordList), [])
+
+  const router = useRouter()
 
   const addWord = useCallback(
     (word: string, enemy: boolean) => {
@@ -81,14 +80,21 @@ const Home: VFC = () => {
       addEnemyWord(displayEnemyWords[count / 2], false)
     }
 
-    // 別ページにデータを送る方法
-    // useContext, Redux Toolkit, jotai
-    // session, react Router, post method?
     if (count >= PLAYING_TIME) {
-      // sessionStorage.setItem('index', String(index))
-      // sessionStorage.setItem('enemyIndex', String(enemyIndex))
-      // window.location.href = '/result'
-      window.location.replace('/result')
+      const wordsString: string = wordsArray.join()
+      const enemyWordsString: string = enemyWordsArray.join()
+      router.push({
+        pathname: `/result`, // 遷移先のページ
+        query: {
+          index: index,
+          enemyIndex: enemyIndex,
+          wordsArray: wordsArray,
+          enemyWordsArray: enemyWordsArray,
+          wordsString: wordsString,
+          enemyWordsString: enemyWordsString,
+        }, // useRouter().queryをそのまま渡せば良い
+        // query: { someParam: `value`, ...router.query }, // 他にも渡したいものがある場合
+      })
     }
     // addWord, addEnemyWordを入れると無限ループするため
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -123,6 +129,8 @@ const Home: VFC = () => {
     }
 
     if (words[index] && text === words[index].value) {
+      console.log(wordsArray)
+      console.log(enemyWordsArray)
       setText('')
       // 相手から送られた単語出ないなら、相手に送る
       if (words[index].enemy == false) {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,10 +1,19 @@
+import { useAtom } from 'jotai'
 import Link from 'next/link'
 import React, { useCallback, useEffect, useMemo, useState, VFC } from 'react'
 import { wordList } from 'dev/wordList'
 import { useTimer } from 'hooks/useTimer'
+import {
+  enemyIndextAtom,
+  enemyTextAtom,
+  enemyWordsAtom,
+  indextAtom,
+  textAtom,
+  wordsAtom,
+} from 'libs/Atom'
 import { shuffleArray } from 'utils/shuffleArray'
 
-const PLAYING_TIME = 10
+const PLAYING_TIME = 20
 
 interface wordData {
   value: string
@@ -12,12 +21,18 @@ interface wordData {
 }
 
 const Home: VFC = () => {
-  const [text, setText] = useState<string>('')
-  const [enemyText, setEnemyText] = useState<string>('')
-  const [index, setIndex] = useState<number>(0)
-  const [enemyIndex, setEnemyIndex] = useState<number>(0)
-  const [words, setWords] = useState<wordData[]>()
-  const [enemyWords, setEnemyWords] = useState<wordData[]>()
+  // const [text, setText] = useState<string>('')
+  // const [enemyText, setEnemyText] = useState<string>('')
+  // const [index, setIndex] = useState<number>(0)
+  // const [enemyIndex, setEnemyIndex] = useState<number>(0)
+  // const [words, setWords] = useState<wordData[]>()
+  // const [enemyWords, setEnemyWords] = useState<wordData[]>()
+  const [text, setText] = useAtom(textAtom)
+  const [enemyText, setEnemyText] = useAtom(enemyTextAtom)
+  const [index, setIndex] = useAtom(indextAtom)
+  const [enemyIndex, setEnemyIndex] = useAtom(enemyIndextAtom)
+  const [words, setWords] = useAtom(wordsAtom)
+  const [enemyWords, setEnemyWords] = useAtom(enemyWordsAtom)
 
   useEffect(() => {
     setWords([{ value: 'start', enemy: false }])
@@ -54,8 +69,15 @@ const Home: VFC = () => {
       addWord(displayWords[count / 2], false)
       addEnemyWord(displayEnemyWords[count / 2], false)
     }
+
+    // 別ページにデータを送る方法
+    // useContext, Redux Toolkit, jotai
+    // session, react Router, post method?
     if (count >= PLAYING_TIME) {
-      window.location.href = '/result'
+      // sessionStorage.setItem('index', String(index))
+      // sessionStorage.setItem('enemyIndex', String(enemyIndex))
+      // window.location.href = '/result'
+      window.location.replace('/result')
     }
     // addWord, addEnemyWordを入れると無限ループするため
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -116,6 +138,8 @@ const Home: VFC = () => {
     index,
     text,
     words,
+    setIndex,
+    setEnemyIndex,
   ])
 
   return (
@@ -124,9 +148,14 @@ const Home: VFC = () => {
         <div className='font-serif text-3xl'>
           {'Timer : ' + (PLAYING_TIME - count)}
         </div>
-        <Link href='chat'>
-          <a>chat</a>
-        </Link>
+        <div className='flex gap-2'>
+          <Link href='/chat'>
+            <a>chat</a>
+          </Link>
+          <Link href='/result'>
+            <a>result</a>
+          </Link>
+        </div>
       </header>
 
       <main>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -81,8 +81,11 @@ const Home: VFC = () => {
     }
 
     if (count >= PLAYING_TIME) {
-      const wordsJson = JSON.stringify(words)
-      const enemyWordsJson = JSON.stringify(enemyWords)
+      const wordsJson: string = JSON.stringify(words).replace(/null,/, '')
+      const enemyWordsJson: string = JSON.stringify(enemyWords).replace(
+        'null,',
+        ''
+      )
       // console.log('words: -> ')
       // console.log(words)
       // console.log('JSON: -> ')

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,15 +6,13 @@ import { wordList } from 'dev/wordList'
 import { useTimer } from 'hooks/useTimer'
 import {
   enemyIndextAtom,
-  enemyWordsArrayAtom,
   enemyWordsAtom,
   indextAtom,
-  wordsArrayAtom,
   wordsAtom,
 } from 'libs/Atom'
 import { shuffleArray } from 'utils/shuffleArray'
 
-const PLAYING_TIME = 20
+const PLAYING_TIME = 60
 
 interface wordData {
   value: string
@@ -24,17 +22,10 @@ interface wordData {
 const Home: VFC = () => {
   const [text, setText] = useState<string>('')
   const [enemyText, setEnemyText] = useState<string>('')
-  // const [index, setIndex] = useState<number>(0)
-  // const [enemyIndex, setEnemyIndex] = useState<number>(0)
-  // const [words, setWords] = useState<wordData[]>()
-  // const [enemyWords, setEnemyWords] = useState<wordData[]>()
   const [index, setIndex] = useAtom(indextAtom)
   const [enemyIndex, setEnemyIndex] = useAtom(enemyIndextAtom)
   const [words, setWords] = useAtom(wordsAtom)
   const [enemyWords, setEnemyWords] = useAtom(enemyWordsAtom)
-
-  const [wordsArray, setWordsArray] = useAtom(wordsArrayAtom)
-  const [enemyWordsArray, setEnemyWordsArray] = useAtom(enemyWordsArrayAtom)
 
   useEffect(() => {
     setWords([{ value: 'start', enemy: false }])
@@ -54,10 +45,6 @@ const Home: VFC = () => {
       if (!words) return
       const newWords = [...words, { value: word, enemy: enemy }]
       setWords(newWords)
-
-      const newWordsArray = [...wordsArray, word]
-      setWordsArray(newWordsArray)
-      console.log('add!!!')
     },
     [words]
   )
@@ -66,9 +53,6 @@ const Home: VFC = () => {
       if (!enemyWords) return
       const newWords = [...enemyWords, { value: word, enemy: enemy }]
       setEnemyWords(newWords)
-
-      const newWordsArray = [...enemyWordsArray, word]
-      setEnemyWordsArray(newWordsArray)
     },
     [enemyWords]
   )
@@ -81,26 +65,8 @@ const Home: VFC = () => {
     }
 
     if (count >= PLAYING_TIME) {
-      const wordsJson: string = JSON.stringify(words).replace(/null,/, '')
-      const enemyWordsJson: string = JSON.stringify(enemyWords).replace(
-        'null,',
-        ''
-      )
-      // console.log('words: -> ')
-      // console.log(words)
-      // console.log('JSON: -> ')
-      // console.log(wordsJson)
-
       router.push({
         pathname: `/result`,
-        query: {
-          index: index,
-          enemyIndex: enemyIndex,
-          wordsArray: wordsArray,
-          enemyWordsArray: enemyWordsArray,
-          words: wordsJson,
-          enemyWords: enemyWordsJson,
-        },
       })
     }
     // addWord, addEnemyWordを入れると無限ループするため

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,7 +4,7 @@ import { wordList } from 'dev/wordList'
 import { useTimer } from 'hooks/useTimer'
 import { shuffleArray } from 'utils/shuffleArray'
 
-const PLAYING_TIME = 60
+const PLAYING_TIME = 10
 
 interface wordData {
   value: string
@@ -18,10 +18,12 @@ const Home: VFC = () => {
   const [enemyIndex, setEnemyIndex] = useState<number>(0)
   const [words, setWords] = useState<wordData[]>()
   const [enemyWords, setEnemyWords] = useState<wordData[]>()
+
   useEffect(() => {
     setWords([{ value: 'start', enemy: false }])
     setEnemyWords([{ value: 'start', enemy: false }])
   }, [])
+
   const { setTimer, count } = useTimer(PLAYING_TIME)
   const [isPlaying, setIsPlaying] = useState(false)
 
@@ -51,6 +53,9 @@ const Home: VFC = () => {
     if (count != 0 && count % 2 == 0) {
       addWord(displayWords[count / 2], false)
       addEnemyWord(displayEnemyWords[count / 2], false)
+    }
+    if (count >= PLAYING_TIME) {
+      window.location.href = '/result'
     }
     // addWord, addEnemyWordを入れると無限ループするため
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -116,7 +121,9 @@ const Home: VFC = () => {
   return (
     <div className='mx-auto mt-4 w-[90%] max-w-[800px]'>
       <header className='flex justify-between'>
-        <div className='font-serif text-3xl'>{'Timer : ' + (60 - count)}</div>
+        <div className='font-serif text-3xl'>
+          {'Timer : ' + (PLAYING_TIME - count)}
+        </div>
         <Link href='chat'>
           <a>chat</a>
         </Link>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -81,19 +81,23 @@ const Home: VFC = () => {
     }
 
     if (count >= PLAYING_TIME) {
-      const wordsString: string = wordsArray.join()
-      const enemyWordsString: string = enemyWordsArray.join()
+      const wordsJson = JSON.stringify(words)
+      const enemyWordsJson = JSON.stringify(enemyWords)
+      // console.log('words: -> ')
+      // console.log(words)
+      // console.log('JSON: -> ')
+      // console.log(wordsJson)
+
       router.push({
-        pathname: `/result`, // 遷移先のページ
+        pathname: `/result`,
         query: {
           index: index,
           enemyIndex: enemyIndex,
           wordsArray: wordsArray,
           enemyWordsArray: enemyWordsArray,
-          wordsString: wordsString,
-          enemyWordsString: enemyWordsString,
-        }, // useRouter().queryをそのまま渡せば良い
-        // query: { someParam: `value`, ...router.query }, // 他にも渡したいものがある場合
+          words: wordsJson,
+          enemyWords: enemyWordsJson,
+        },
       })
     }
     // addWord, addEnemyWordを入れると無限ループするため
@@ -129,8 +133,6 @@ const Home: VFC = () => {
     }
 
     if (words[index] && text === words[index].value) {
-      console.log(wordsArray)
-      console.log(enemyWordsArray)
       setText('')
       // 相手から送られた単語出ないなら、相手に送る
       if (words[index].enemy == false) {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -117,7 +117,9 @@ const Home: VFC = () => {
     <div className='mx-auto mt-4 w-[90%] max-w-[800px]'>
       <header className='flex justify-between'>
         <div className='font-serif text-3xl'>{'Timer : ' + (60 - count)}</div>
-        <Link href='chat'>chat</Link>
+        <Link href='chat'>
+          <a>chat</a>
+        </Link>
       </header>
 
       <main>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,9 +6,11 @@ import { useTimer } from 'hooks/useTimer'
 import {
   enemyIndextAtom,
   enemyTextAtom,
+  enemyWordsArrayAtom,
   enemyWordsAtom,
   indextAtom,
   textAtom,
+  wordsArrayAtom,
   wordsAtom,
 } from 'libs/Atom'
 import { shuffleArray } from 'utils/shuffleArray'
@@ -34,6 +36,9 @@ const Home: VFC = () => {
   const [words, setWords] = useAtom(wordsAtom)
   const [enemyWords, setEnemyWords] = useAtom(enemyWordsAtom)
 
+  const [wordsArray, setWordsArray] = useAtom(wordsArrayAtom)
+  const [enemyWordsArray, setEnemyWordsArray] = useAtom(enemyWordsArrayAtom)
+
   useEffect(() => {
     setWords([{ value: 'start', enemy: false }])
     setEnemyWords([{ value: 'start', enemy: false }])
@@ -50,6 +55,9 @@ const Home: VFC = () => {
       if (!words) return
       const newWords = [...words, { value: word, enemy: enemy }]
       setWords(newWords)
+
+      const newWordsArray = [...wordsArray, word]
+      setWordsArray(newWordsArray)
       console.log('add!!!')
     },
     [words]
@@ -59,6 +67,9 @@ const Home: VFC = () => {
       if (!enemyWords) return
       const newWords = [...enemyWords, { value: word, enemy: enemy }]
       setEnemyWords(newWords)
+
+      const newWordsArray = [...enemyWordsArray, word]
+      setEnemyWordsArray(newWordsArray)
     },
     [enemyWords]
   )

--- a/src/pages/result.tsx
+++ b/src/pages/result.tsx
@@ -1,69 +1,20 @@
+import { useAtom } from 'jotai'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { VFC } from 'react'
+import {
+  enemyIndextAtom,
+  enemyWordsAtom,
+  indextAtom,
+  wordsAtom,
+} from 'libs/Atom'
 
 const Result: VFC = () => {
-  // session
-  // const [loading, setLoading] = useState<boolean>(true)
-  // const [index, setIndex] = useState<string>('')
-  // const [enemyIndex, setEnemyIndex] = useState<string>('')
-  // useEffect(() => {
-  //   // const index = sessionStorage.getItem('index')
-  //   // const enemyIndex = sessionStorage.getItem('enemyIndex')
-  //   // setIndex(sessionStorage.getItem('index'))
-  //   if (index && enemyIndex) setLoading(false)
-  //   console.log(index)
-  //   console.log(enemyIndex)
-  // }, [])
-
-  // // const [index, setIndex] = useState(sessionStorage.getItem('index'))
-  // // const [enemyIndex, setEnemyIndex] = useState(
-  // //   sessionStorage.getItem('enemyIndex')
-  // )
-
-  // jotai
-  // const [index] = useAtom(indextAtom)
-  // const [enemyIndex] = useAtom(enemyIndextAtom)
-  // const [words] = useAtom(wordsAtom)
-  // const [enemyWords] = useAtom(enemyWordsAtom)
-
-  // const [wordsArray] = useAtom(wordsArrayAtom)
-  // const [enemyWordsArray] = useAtom(enemyWordsArrayAtom)
-
-  // useRouter
   const router = useRouter()
-  // const words = useMemo(() => {
-  //   if (!router.query.words) {
-  //     return []
-  //   }
-  //   return JSON.parse(router.query.words![0])
-  // }, [])
-
-  // const words = router.query.words || ''
-
-  // console.log(JSON.parse(words))
-
-  // JSON.parse(router.query.words?[0])
-  // const object = router.query.words
-  console.log(router.query.words)
-  const json = router.query.words
-  console.log(JSON.parse(String(json)))
-  const words = JSON.parse(String(json))
-  // console.log(JSON.parse(String(router.query.words) || ''))
-  const myObj = [
-    { value: 'start', enemy: true },
-    { value: 'undertake', enemy: false },
-    { value: 'urge', enemy: true },
-    { value: 'trickle', enemy: false },
-  ]
-  const myObjStr = JSON.stringify(myObj)
-  console.log('myObj -> ')
-  console.log(myObj)
-  console.log('JSON -> ')
-  console.log(myObjStr)
-  console.log(JSON.parse(myObjStr))
-
-  // console.log(JSON.parse(myObject))
+  const [index] = useAtom(indextAtom)
+  const [enemyIndex] = useAtom(enemyIndextAtom)
+  const [words] = useAtom(wordsAtom)
+  const [enemyWords] = useAtom(enemyWordsAtom)
 
   return (
     <div className='mx-auto mt-4 w-[90%] max-w-[800px] text-xl'>
@@ -71,95 +22,41 @@ const Result: VFC = () => {
         <a>typing</a>
       </Link>
 
-      {/* jotai */}
-      {/* <div className='mt-10'>
-        <div className='mb-4 text-3xl font-bold'>jotai</div>
-        <div className='flex gap-36'>
-          <div>{'myIndex: ' + index}</div>
-          <div>{'enemyIndex: ' + enemyIndex}</div>
-        </div>
-        <div className='mt-4'>
-          {words && enemyWords && (
-            <>
-              <div className='flex gap-4'>
-                <ul>
-                  <li className='mb-2'>全ての単語</li>
-                  {wordsArray.map((v, i) => (
-                    <li key={i}>{v}</li>
-                  ))}
-                </ul>
-
-                <ul>
-                  <li className='mb-2'>打った単語</li>
-                  {wordsArray.map((v, i) => (
-                    <li key={i}>{i < index && v}</li>
-                  ))}
-                </ul>
-                <ul>
-                  <li className='mb-2'>敵の全ての単語</li>
-                  {enemyWordsArray.map((v, i) => (
-                    <li key={i}>{v}</li>
-                  ))}
-                </ul>
-
-                <ul>
-                  <li className='mb-2'>敵の打った単語</li>
-                  {enemyWordsArray.map((v, i) => (
-                    <li key={i}>{i < enemyIndex && v}</li>
-                  ))}
-                </ul>
-              </div>
-            </>
-          )}
-        </div>
-      </div> */}
-
-      {/* useRouterからのデータ */}
       <div className='mt-10'>
         <div className='mb-4 text-3xl font-bold'>useRouter</div>
         <div className='flex gap-36'>
-          <div>{'myIndex: ' + router.query.index}</div>
-          <div>{'enemyIndex: ' + router.query.enemyIndex}</div>
+          <div>{'myIndex: ' + index}</div>
+          <div>{'enemyIndex: ' + enemyIndex}</div>
         </div>
         <div className='mt-4'>
           <>
             <div className='flex gap-4'>
               <ul>
                 <li className='mb-2'>全ての単語</li>
-                {typeof router.query.wordsArray === 'object' &&
-                  router.query.wordsArray.map((v, i) => <li key={i}>{v}</li>)}
-                <br></br>
-                {words.map((v, i) => (
-                  <li key={i}>{v}</li>
-                ))}
-                {/* {JSON.parse(router.query.words)} */}
-
-                {router.query.words}
-                <br></br>
-                <br></br>
-                {myObjStr}
+                {typeof words === 'object' &&
+                  words.map((v, i) => <li key={i}>{v && v.value}</li>)}
+                <br />
+                <br />
               </ul>
 
               <ul>
                 <li className='mb-2'>打った単語</li>
-                {typeof router.query.wordsArray === 'object' &&
-                  router.query.wordsArray.map((v, i) => (
-                    <li key={i}>{i < Number(router.query.index) && v}</li>
+                {typeof words === 'object' &&
+                  words.map((v, i) => (
+                    <li key={i}>{i < Number(index) && v && v.value}</li>
                   ))}
               </ul>
               <ul>
                 <li className='mb-2'>敵の全ての単語</li>
-                {typeof router.query.enemyWordsArray === 'object' &&
-                  router.query.enemyWordsArray.map((v, i) => (
-                    <li key={i}>{v}</li>
-                  ))}
+                {typeof enemyWords === 'object' &&
+                  enemyWords.map((v, i) => <li key={i}>{v && v.value}</li>)}
               </ul>
 
               <ul>
                 <li className='mb-2'>敵の打った単語</li>
-                {typeof router.query.enemyWordsArray === 'object' &&
-                  router.query.enemyWordsArray.map((v, i) => (
-                    <li key={i}>{i < Number(router.query.enemyIndex) && v}</li>
+                {typeof enemyWords === 'object' &&
+                  enemyWords.map((v, i) => (
+                    <li key={i}>{i < Number(enemyIndex) && v && v.value}</li>
                   ))}
               </ul>
             </div>

--- a/src/pages/result.tsx
+++ b/src/pages/result.tsx
@@ -1,17 +1,17 @@
 import { useAtom } from 'jotai'
 import Link from 'next/link'
+import { useRouter } from 'next/router'
 import { VFC } from 'react'
 import {
   enemyIndextAtom,
-  enemyTextAtom,
   enemyWordsArrayAtom,
   enemyWordsAtom,
   indextAtom,
-  textAtom,
   wordsArrayAtom,
   wordsAtom,
 } from 'libs/Atom'
 const Result: VFC = () => {
+  // session
   // const [loading, setLoading] = useState<boolean>(true)
   // const [index, setIndex] = useState<string>('')
   // const [enemyIndex, setEnemyIndex] = useState<string>('')
@@ -29,8 +29,7 @@ const Result: VFC = () => {
   // //   sessionStorage.getItem('enemyIndex')
   // )
 
-  const [text] = useAtom(textAtom)
-  const [enemyText] = useAtom(enemyTextAtom)
+  // jotai
   const [index] = useAtom(indextAtom)
   const [enemyIndex] = useAtom(enemyIndextAtom)
   const [words] = useAtom(wordsAtom)
@@ -38,43 +37,27 @@ const Result: VFC = () => {
 
   const [wordsArray] = useAtom(wordsArrayAtom)
   const [enemyWordsArray] = useAtom(enemyWordsArrayAtom)
+
+  // useRouter
+  const router = useRouter()
+
   return (
     <div className='mx-auto mt-4 w-[90%] max-w-[800px] text-xl'>
       <Link href='/'>
         <a>typing</a>
       </Link>
+
+      {/* jotai */}
       <div className='mt-10'>
+        <div className='mb-4 text-3xl font-bold'>jotai</div>
         <div className='flex gap-36'>
-          <div>{'myIndex: ' + index + text}</div>
-          <div>{'enemyIndex: ' + enemyIndex + enemyText}</div>
+          <div>{'myIndex: ' + index}</div>
+          <div>{'enemyIndex: ' + enemyIndex}</div>
         </div>
-        <div className='mt-10'>
-          {/* <ul>
-            {words.map((v, i) => (
-              <li key={i}>{v.value}</li>
-            ))}
-          </ul>
-          <ul>
-            {enemyWords.map((v, i) => (
-              <li key={i}>{v.value}</li>
-            ))}
-          </ul> */}
+        <div className='mt-4'>
           {words && enemyWords && (
             <>
-              {/* <div>{words[0].value}</div>
-              <div>{enemyWords[0].value}</div> */}
               <div className='flex gap-4'>
-                {/* <ul>
-                  {words.map((v, i) => (
-                    <li key={i}>{v.value}</li>
-                  ))}
-                </ul>
-                <ul>
-                  {enemyWords.map((v, i) => (
-                    <li key={i}>{v.value}</li>
-                  ))}
-                </ul> */}
-
                 <ul>
                   <li className='mb-2'>全ての単語</li>
                   {wordsArray.map((v, i) => (
@@ -104,6 +87,49 @@ const Result: VFC = () => {
               </div>
             </>
           )}
+        </div>
+      </div>
+
+      {/* useRouterからのデータ */}
+      <div className='mt-10'>
+        <div className='mb-4 text-3xl font-bold'>useRouter</div>
+        <div className='flex gap-36'>
+          <div>{'myIndex: ' + router.query.index}</div>
+          <div>{'enemyIndex: ' + router.query.enemyIndex}</div>
+        </div>
+        <div className='mt-4'>
+          <>
+            <div className='flex gap-4'>
+              <ul>
+                <li className='mb-2'>全ての単語</li>
+                {typeof router.query.wordsArray === 'object' &&
+                  router.query.wordsArray.map((v, i) => <li key={i}>{v}</li>)}
+              </ul>
+
+              <ul>
+                <li className='mb-2'>打った単語</li>
+                {typeof router.query.wordsArray === 'object' &&
+                  router.query.wordsArray.map((v, i) => (
+                    <li key={i}>{i < Number(router.query.index) && v}</li>
+                  ))}
+              </ul>
+              <ul>
+                <li className='mb-2'>敵の全ての単語</li>
+                {typeof router.query.enemyWordsArray === 'object' &&
+                  router.query.enemyWordsArray.map((v, i) => (
+                    <li key={i}>{v}</li>
+                  ))}
+              </ul>
+
+              <ul>
+                <li className='mb-2'>敵の打った単語</li>
+                {typeof router.query.enemyWordsArray === 'object' &&
+                  router.query.enemyWordsArray.map((v, i) => (
+                    <li key={i}>{i < Number(router.query.enemyIndex) && v}</li>
+                  ))}
+              </ul>
+            </div>
+          </>
         </div>
       </div>
     </div>

--- a/src/pages/result.tsx
+++ b/src/pages/result.tsx
@@ -47,20 +47,14 @@ const Result: VFC = () => {
   // const object = router.query.words
   console.log(router.query.words)
   const json = router.query.words
-  console.log(typeof json)
-  // console.log(JSON.parse(router.query.words))
-
+  console.log(JSON.parse(String(json)))
+  const words = JSON.parse(String(json))
+  // console.log(JSON.parse(String(router.query.words) || ''))
   const myObj = [
-    {
-      name: 'Skip',
-      age: 2,
-      favoriteFood: 'Steak',
-    },
-    {
-      name: 'Akio',
-      age: 20,
-      favoriteFood: 'ticken',
-    },
+    { value: 'start', enemy: true },
+    { value: 'undertake', enemy: false },
+    { value: 'urge', enemy: true },
+    { value: 'trickle', enemy: false },
   ]
   const myObjStr = JSON.stringify(myObj)
   console.log('myObj -> ')
@@ -69,23 +63,7 @@ const Result: VFC = () => {
   console.log(myObjStr)
   console.log(JSON.parse(myObjStr))
 
-  const myObject =
-    "[{ name: 'Skip', age: 2, favoriteFood: 'Steak' },{ name: 'Akio', age: 20, favoriteFood: 'ticken' },]"
-
-  const wordsObject = [
-    { value: 'start', enemy: true },
-    { value: 'undertake', enemy: false },
-    { value: 'urge', enemy: true },
-    { value: 'trickle', enemy: false },
-    { value: 'twist', enemy: false },
-    { value: 'tyranny', enemy: false },
-    { value: 'twofold', enemy: false },
-    { value: 'unbridled', enemy: false },
-    { value: 'turn up', enemy: false },
-    { value: 'tuition', enemy: false },
-  ]
-
-  console.log(JSON.parse(myObject))
+  // console.log(JSON.parse(myObject))
 
   return (
     <div className='mx-auto mt-4 w-[90%] max-w-[800px] text-xl'>
@@ -151,11 +129,15 @@ const Result: VFC = () => {
                 {typeof router.query.wordsArray === 'object' &&
                   router.query.wordsArray.map((v, i) => <li key={i}>{v}</li>)}
                 <br></br>
-                {/* {JSON.parse(router.query.words).map((v, i) => (
-                  <li key={i}>{v.value}</li>
-                ))} */}
+                {words.map((v, i) => (
+                  <li key={i}>{v}</li>
+                ))}
                 {/* {JSON.parse(router.query.words)} */}
+
                 {router.query.words}
+                <br></br>
+                <br></br>
+                {myObjStr}
               </ul>
 
               <ul>

--- a/src/pages/result.tsx
+++ b/src/pages/result.tsx
@@ -4,9 +4,11 @@ import { VFC } from 'react'
 import {
   enemyIndextAtom,
   enemyTextAtom,
+  enemyWordsArrayAtom,
   enemyWordsAtom,
   indextAtom,
   textAtom,
+  wordsArrayAtom,
   wordsAtom,
 } from 'libs/Atom'
 const Result: VFC = () => {
@@ -33,13 +35,16 @@ const Result: VFC = () => {
   const [enemyIndex] = useAtom(enemyIndextAtom)
   const [words] = useAtom(wordsAtom)
   const [enemyWords] = useAtom(enemyWordsAtom)
+
+  const [wordsArray] = useAtom(wordsArrayAtom)
+  const [enemyWordsArray] = useAtom(enemyWordsArrayAtom)
   return (
     <div className='mx-auto mt-4 w-[90%] max-w-[800px] text-xl'>
       <Link href='/'>
         <a>typing</a>
       </Link>
       <div className='mt-10'>
-        <div className='flex gap-4'>
+        <div className='flex gap-36'>
           <div>{'myIndex: ' + index + text}</div>
           <div>{'enemyIndex: ' + enemyIndex + enemyText}</div>
         </div>
@@ -59,7 +64,7 @@ const Result: VFC = () => {
               {/* <div>{words[0].value}</div>
               <div>{enemyWords[0].value}</div> */}
               <div className='flex gap-4'>
-                <ul>
+                {/* <ul>
                   {words.map((v, i) => (
                     <li key={i}>{v.value}</li>
                   ))}
@@ -67,6 +72,33 @@ const Result: VFC = () => {
                 <ul>
                   {enemyWords.map((v, i) => (
                     <li key={i}>{v.value}</li>
+                  ))}
+                </ul> */}
+
+                <ul>
+                  <li className='mb-2'>全ての単語</li>
+                  {wordsArray.map((v, i) => (
+                    <li key={i}>{v}</li>
+                  ))}
+                </ul>
+
+                <ul>
+                  <li className='mb-2'>打った単語</li>
+                  {wordsArray.map((v, i) => (
+                    <li key={i}>{i < index && v}</li>
+                  ))}
+                </ul>
+                <ul>
+                  <li className='mb-2'>敵の全ての単語</li>
+                  {enemyWordsArray.map((v, i) => (
+                    <li key={i}>{v}</li>
+                  ))}
+                </ul>
+
+                <ul>
+                  <li className='mb-2'>敵の打った単語</li>
+                  {enemyWordsArray.map((v, i) => (
+                    <li key={i}>{i < enemyIndex && v}</li>
                   ))}
                 </ul>
               </div>

--- a/src/pages/result.tsx
+++ b/src/pages/result.tsx
@@ -1,13 +1,80 @@
+import { useAtom } from 'jotai'
 import Link from 'next/link'
 import { VFC } from 'react'
+import {
+  enemyIndextAtom,
+  enemyTextAtom,
+  enemyWordsAtom,
+  indextAtom,
+  textAtom,
+  wordsAtom,
+} from 'libs/Atom'
 const Result: VFC = () => {
+  // const [loading, setLoading] = useState<boolean>(true)
+  // const [index, setIndex] = useState<string>('')
+  // const [enemyIndex, setEnemyIndex] = useState<string>('')
+  // useEffect(() => {
+  //   // const index = sessionStorage.getItem('index')
+  //   // const enemyIndex = sessionStorage.getItem('enemyIndex')
+  //   // setIndex(sessionStorage.getItem('index'))
+  //   if (index && enemyIndex) setLoading(false)
+  //   console.log(index)
+  //   console.log(enemyIndex)
+  // }, [])
+
+  // // const [index, setIndex] = useState(sessionStorage.getItem('index'))
+  // // const [enemyIndex, setEnemyIndex] = useState(
+  // //   sessionStorage.getItem('enemyIndex')
+  // )
+
+  const [text] = useAtom(textAtom)
+  const [enemyText] = useAtom(enemyTextAtom)
+  const [index] = useAtom(indextAtom)
+  const [enemyIndex] = useAtom(enemyIndextAtom)
+  const [words] = useAtom(wordsAtom)
+  const [enemyWords] = useAtom(enemyWordsAtom)
   return (
-    <>
-      <Link href='index'>
+    <div className='mx-auto mt-4 w-[90%] max-w-[800px] text-xl'>
+      <Link href='/'>
         <a>typing</a>
       </Link>
-      <div>Result画面だよ</div>
-    </>
+      <div className='mt-10'>
+        <div className='flex gap-4'>
+          <div>{'myIndex: ' + index + text}</div>
+          <div>{'enemyIndex: ' + enemyIndex + enemyText}</div>
+        </div>
+        <div className='mt-10'>
+          {/* <ul>
+            {words.map((v, i) => (
+              <li key={i}>{v.value}</li>
+            ))}
+          </ul>
+          <ul>
+            {enemyWords.map((v, i) => (
+              <li key={i}>{v.value}</li>
+            ))}
+          </ul> */}
+          {words && enemyWords && (
+            <>
+              {/* <div>{words[0].value}</div>
+              <div>{enemyWords[0].value}</div> */}
+              <div className='flex gap-4'>
+                <ul>
+                  {words.map((v, i) => (
+                    <li key={i}>{v.value}</li>
+                  ))}
+                </ul>
+                <ul>
+                  {enemyWords.map((v, i) => (
+                    <li key={i}>{v.value}</li>
+                  ))}
+                </ul>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
   )
 }
 

--- a/src/pages/result.tsx
+++ b/src/pages/result.tsx
@@ -1,15 +1,7 @@
-import { useAtom } from 'jotai'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { VFC } from 'react'
-import {
-  enemyIndextAtom,
-  enemyWordsArrayAtom,
-  enemyWordsAtom,
-  indextAtom,
-  wordsArrayAtom,
-  wordsAtom,
-} from 'libs/Atom'
+
 const Result: VFC = () => {
   // session
   // const [loading, setLoading] = useState<boolean>(true)
@@ -30,16 +22,70 @@ const Result: VFC = () => {
   // )
 
   // jotai
-  const [index] = useAtom(indextAtom)
-  const [enemyIndex] = useAtom(enemyIndextAtom)
-  const [words] = useAtom(wordsAtom)
-  const [enemyWords] = useAtom(enemyWordsAtom)
+  // const [index] = useAtom(indextAtom)
+  // const [enemyIndex] = useAtom(enemyIndextAtom)
+  // const [words] = useAtom(wordsAtom)
+  // const [enemyWords] = useAtom(enemyWordsAtom)
 
-  const [wordsArray] = useAtom(wordsArrayAtom)
-  const [enemyWordsArray] = useAtom(enemyWordsArrayAtom)
+  // const [wordsArray] = useAtom(wordsArrayAtom)
+  // const [enemyWordsArray] = useAtom(enemyWordsArrayAtom)
 
   // useRouter
   const router = useRouter()
+  // const words = useMemo(() => {
+  //   if (!router.query.words) {
+  //     return []
+  //   }
+  //   return JSON.parse(router.query.words![0])
+  // }, [])
+
+  // const words = router.query.words || ''
+
+  // console.log(JSON.parse(words))
+
+  // JSON.parse(router.query.words?[0])
+  // const object = router.query.words
+  console.log(router.query.words)
+  const json = router.query.words
+  console.log(typeof json)
+  // console.log(JSON.parse(router.query.words))
+
+  const myObj = [
+    {
+      name: 'Skip',
+      age: 2,
+      favoriteFood: 'Steak',
+    },
+    {
+      name: 'Akio',
+      age: 20,
+      favoriteFood: 'ticken',
+    },
+  ]
+  const myObjStr = JSON.stringify(myObj)
+  console.log('myObj -> ')
+  console.log(myObj)
+  console.log('JSON -> ')
+  console.log(myObjStr)
+  console.log(JSON.parse(myObjStr))
+
+  const myObject =
+    "[{ name: 'Skip', age: 2, favoriteFood: 'Steak' },{ name: 'Akio', age: 20, favoriteFood: 'ticken' },]"
+
+  const wordsObject = [
+    { value: 'start', enemy: true },
+    { value: 'undertake', enemy: false },
+    { value: 'urge', enemy: true },
+    { value: 'trickle', enemy: false },
+    { value: 'twist', enemy: false },
+    { value: 'tyranny', enemy: false },
+    { value: 'twofold', enemy: false },
+    { value: 'unbridled', enemy: false },
+    { value: 'turn up', enemy: false },
+    { value: 'tuition', enemy: false },
+  ]
+
+  console.log(JSON.parse(myObject))
 
   return (
     <div className='mx-auto mt-4 w-[90%] max-w-[800px] text-xl'>
@@ -48,7 +94,7 @@ const Result: VFC = () => {
       </Link>
 
       {/* jotai */}
-      <div className='mt-10'>
+      {/* <div className='mt-10'>
         <div className='mb-4 text-3xl font-bold'>jotai</div>
         <div className='flex gap-36'>
           <div>{'myIndex: ' + index}</div>
@@ -88,7 +134,7 @@ const Result: VFC = () => {
             </>
           )}
         </div>
-      </div>
+      </div> */}
 
       {/* useRouterからのデータ */}
       <div className='mt-10'>
@@ -104,6 +150,12 @@ const Result: VFC = () => {
                 <li className='mb-2'>全ての単語</li>
                 {typeof router.query.wordsArray === 'object' &&
                   router.query.wordsArray.map((v, i) => <li key={i}>{v}</li>)}
+                <br></br>
+                {/* {JSON.parse(router.query.words).map((v, i) => (
+                  <li key={i}>{v.value}</li>
+                ))} */}
+                {/* {JSON.parse(router.query.words)} */}
+                {router.query.words}
               </ul>
 
               <ul>

--- a/src/pages/result.tsx
+++ b/src/pages/result.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import { VFC } from 'react'
-export const Result: VFC = () => {
+const Result: VFC = () => {
   return (
     <>
       <Link href='index'>
@@ -10,3 +10,5 @@ export const Result: VFC = () => {
     </>
   )
 }
+
+export default Result

--- a/src/pages/result.tsx
+++ b/src/pages/result.tsx
@@ -1,0 +1,12 @@
+import Link from 'next/link'
+import { VFC } from 'react'
+export const Result: VFC = () => {
+  return (
+    <>
+      <Link href='index'>
+        <a>typing</a>
+      </Link>
+      <div>Result画面だよ</div>
+    </>
+  )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2230,6 +2230,11 @@ jose@^2.0.5:
   dependencies:
     "@panva/asn1.js" "^1.0.0"
 
+jotai@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/jotai/-/jotai-1.6.1.tgz#a6379d7dce159474f24963921d55ae8f6e9e8dd6"
+  integrity sha512-iNKHmpKGN31KXDqxGLsplb4HLTroYtiM7oBEQ9leyoXSEGQGUZKK5IOV4kN6fUmkBSJbwb5WnmInYOYzpjIDOw==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
##  注意
- マージしないで！
- 報告したいだけ

## 概要
- resultページにindexページのデータを送信

## 詳細
### データ受け渡しの問題
- useContext, jotai, Redux Toolkit, jotai, sessionどれ使う？
- まずsessionStorageを使おうとした。
  - sesseionStorageは文字列しか送れない (オブジェクトは、文字列に変換すればいけるらしい)
  - 試しに indexをsessionにセットするのはできたが、resultで表示ができなかった。useEffectとかで１回限りの中でないと、sessionStorageは使えなかった。
  - resultでuseEffectを使って、sessionを取得してconsole.logで表示まではできた。でも、画面に表示は何かできなかった。
 
- 次にjotaiを使い、stateをグローバルで管理できるようにした。
  - jotaiは使いやすくコードの変更点も少なかった。useContext、redux toolkitとかはコードの変更が多くなりそう。
  - jotai は、なぜかresultでwords[ { } ]の値 ( 配列の中にオブジェクト ) を表示できなかった。words[0].value とかでエラー。indexだと使えた。
  - wordsのデータを、普通の配列としてvalueだけを格納したらresultでも表示できた。

### 画面遷移の問題
- 自動で画面遷移は、window.location.href = "/result"で出来た。でも、繊維の仕方がaタグと同じ ( 画面がリロードされちゃう ) だから、state が死ぬ。
  - 遷移の仕方を変える。調べてみるとreact-router, react-router-domで遷移する記事が沢山あった。
  - stateだと保存できないから、sessionを使う。
- 普通に<Link>でresultに遷移するとjotai のstateデータが反映されていた。


![スクリーンショット 2022-03-27 231531](https://user-images.githubusercontent.com/88410576/160285768-8c89dcd6-a42b-48ec-86aa-4c8519ba3d7e.png)

