### PR TITLE
indexページのUI変更 #26

### DIFF
--- a/src/components/TypingField.tsx
+++ b/src/components/TypingField.tsx
@@ -7,6 +7,7 @@ type Props = {
   words: Word[]
   disabled?: boolean
   onCorrect: (word: Word) => void
+  myTextField: boolean
 }
 
 export const TypingField: VFC<Props> = ({
@@ -14,6 +15,7 @@ export const TypingField: VFC<Props> = ({
   words,
   disabled = false,
   onCorrect,
+  myTextField,
 }) => {
   const [text, setText] = useState('')
 
@@ -38,36 +40,53 @@ export const TypingField: VFC<Props> = ({
     >
       <ul className='flex flex-col-reverse h-[250px]'>
         {words.map((word, i) => (
-          <li key={i}>{i > 0 && word.value}</li>
+          <li
+            key={i}
+            className={`${
+              word.userName != 'bot' &&
+              'underline underline-offset-2 text-emerald-600 animate-pulse'
+            }`}
+          >
+            {i > 0 && i < 10 && word.value}
+          </li>
         ))}
       </ul>
 
       {/* 入力する単語 */}
       <div className='text-center'>
-        <div className='h-[40px] text-3xl'>
-          {words[0]?.value &&
-            words[0].value.split('').map((v, i) => (
+        {words[0]?.value && (
+          <div
+            className={`h-[40px] text-3xl ${
+              words[0].userName != 'bot' && 'underline underline-offset-2'
+            }`}
+          >
+            {words[0].value.split('').map((word, i) => (
               <span
                 key={i}
                 className={clsx(
                   text.length > i &&
                     words[0].value?.split('')[i] !== text.split('')[i] &&
-                    'text-red-500'
+                    'text-red-500',
+                  words[0].userName != 'bot' &&
+                    'text-emerald-600 underline underline-offset-2'
                 )}
               >
-                {v}
+                {word}
               </span>
             ))}
-        </div>
+          </div>
+        )}
 
-        <input
-          type='text'
-          className='my-2 text-xl border-2 border-black'
-          autoFocus
-          value={text}
-          onChange={onChange}
-          disabled={disabled}
-        />
+        {myTextField && (
+          <input
+            type='text'
+            className='my-2 text-xl border-2 border-black'
+            autoFocus
+            value={text}
+            onChange={onChange}
+            disabled={disabled}
+          />
+        )}
       </div>
       {/* <div className='font-serif text-[50px] text-center'>
           <div>{index}</div>

--- a/src/components/TypingField.tsx
+++ b/src/components/TypingField.tsx
@@ -7,7 +7,7 @@ type Props = {
   words: Word[]
   disabled?: boolean
   onCorrect: (word: Word) => void
-  myTextField: boolean
+  textInputHidden: boolean
 }
 
 export const TypingField: VFC<Props> = ({
@@ -15,7 +15,7 @@ export const TypingField: VFC<Props> = ({
   words,
   disabled = false,
   onCorrect,
-  myTextField,
+  textInputHidden,
 }) => {
   const [text, setText] = useState('')
 
@@ -42,10 +42,10 @@ export const TypingField: VFC<Props> = ({
         {words.map((word, i) => (
           <li
             key={i}
-            className={`${
-              word.userName != 'bot' &&
-              'underline underline-offset-2 text-emerald-600 animate-pulse'
-            }`}
+            className={clsx(
+              word.type === 'obstacle' &&
+                'text-emerald-600 underline underline-offset-2 animate-pulse'
+            )}
           >
             {i > 0 && i < 10 && word.value}
           </li>
@@ -56,9 +56,10 @@ export const TypingField: VFC<Props> = ({
       <div className='text-center'>
         {words[0]?.value && (
           <div
-            className={`h-[40px] text-3xl ${
-              words[0].userName != 'bot' && 'underline underline-offset-2'
-            }`}
+            className={clsx(
+              'h-[40px] text-3xl',
+              words[0].type === 'obstacle' && 'underline underline-offset-2'
+            )}
           >
             {words[0].value.split('').map((word, i) => (
               <span
@@ -67,7 +68,7 @@ export const TypingField: VFC<Props> = ({
                   text.length > i &&
                     words[0].value?.split('')[i] !== text.split('')[i] &&
                     'text-red-500',
-                  words[0].userName != 'bot' &&
+                  words[0].type === 'obstacle' &&
                     'text-emerald-600 underline underline-offset-2'
                 )}
               >
@@ -77,7 +78,7 @@ export const TypingField: VFC<Props> = ({
           </div>
         )}
 
-        {myTextField && (
+        {textInputHidden && (
           <input
             type='text'
             className='my-2 text-xl border-2 border-black'

--- a/src/components/TypingField.tsx
+++ b/src/components/TypingField.tsx
@@ -7,7 +7,7 @@ type Props = {
   words: Word[]
   disabled?: boolean
   onCorrect: (word: Word) => void
-  textInputHidden: boolean
+  textInputHidden?: boolean
 }
 
 export const TypingField: VFC<Props> = ({
@@ -15,7 +15,7 @@ export const TypingField: VFC<Props> = ({
   words,
   disabled = false,
   onCorrect,
-  textInputHidden,
+  textInputHidden = false,
 }) => {
   const [text, setText] = useState('')
 

--- a/src/components/TypingField.tsx
+++ b/src/components/TypingField.tsx
@@ -78,7 +78,7 @@ export const TypingField: VFC<Props> = ({
           </div>
         )}
 
-        {textInputHidden && (
+        {!textInputHidden && (
           <input
             type='text'
             className='my-2 text-xl border-2 border-black'

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -66,7 +66,7 @@ const Home: VFC = () => {
                 words={displayWords}
                 disabled={!count}
                 onCorrect={onCorrect}
-                myTextField={true}
+                textInputHidden={true}
               />
               <TypingField
                 words={displayEnemyWords}
@@ -74,7 +74,7 @@ const Home: VFC = () => {
                 onCorrect={() => {
                   console.log('correct!')
                 }}
-                myTextField={false}
+                textInputHidden={false}
               />
             </>
           )}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -66,13 +66,13 @@ const Home: VFC = () => {
                 words={displayWords}
                 disabled={!count}
                 onCorrect={onCorrect}
-                textInputHidden
               />
               <TypingField
                 words={displayEnemyWords}
                 onCorrect={() => {
                   console.log('correct!')
                 }}
+                textInputHidden
               />
             </>
           )}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -66,15 +66,13 @@ const Home: VFC = () => {
                 words={displayWords}
                 disabled={!count}
                 onCorrect={onCorrect}
-                textInputHidden={true}
+                textInputHidden
               />
               <TypingField
                 words={displayEnemyWords}
-                disabled={!count}
                 onCorrect={() => {
                   console.log('correct!')
                 }}
-                textInputHidden={false}
               />
             </>
           )}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -66,6 +66,7 @@ const Home: VFC = () => {
                 words={displayWords}
                 disabled={!count}
                 onCorrect={onCorrect}
+                myTextField={true}
               />
               <TypingField
                 words={displayEnemyWords}
@@ -73,6 +74,7 @@ const Home: VFC = () => {
                 onCorrect={() => {
                   console.log('correct!')
                 }}
+                myTextField={false}
               />
             </>
           )}


### PR DESCRIPTION
# 概要
- indexページのUI変更
[#26](https://github.com/tosssssy/typing-battle/issues/26)



# 詳細
- UI変更
  - 単語がはみ出ないよう修正 
  - 相手のinputを削除
  - 相手の妨害を分かりやすく
- リファクタリング
  - classNameで変数を使う個所でclsxを使用
  - words[0].userName としていた個所を、words[0].typeに変更
  - myTextFieldの個所をtextInputHiddenに変更

相手の単語の文字を緑色にし、アンダーラインをつけた。
![スクリーンショット 2022-03-29 232854](https://user-images.githubusercontent.com/88410576/160635561-c507f319-663c-450c-8239-18f00e0d4fef.png)



また、words[1]~の単語はアニメーションで少し、透明度が変化する。
( animate-pulse )
![スクリーンショット 2022-03-29 233002](https://user-images.githubusercontent.com/88410576/160635601-84fb77c0-40cf-4155-b973-3d03b259c11e.png)



# 質問

なし
